### PR TITLE
Update compute_pvalues for deduplicated mapping

### DIFF
--- a/DeepHisCoM_simulation.py
+++ b/DeepHisCoM_simulation.py
@@ -159,11 +159,17 @@ def main():
     df_meta = pd.read_csv("181_metabolite_clinical.csv", index_col=0)
     metabolite = df_meta.iloc[:,14:]
     mapping = load_mapping(args.mapping_file)
-    annot = pd.DataFrame([{"metabolite":m,"group":g} for g,ms in mapping.items() for m in ms if m in metabolite.columns])
-    metabolite = metabolite[annot["metabolite"].unique()]
-    eps=1e-6; X_log=np.log(metabolite.values+eps)
-    X_scaled=StandardScaler().fit_transform(X_log); metabolite_scaled=pd.DataFrame(X_scaled,columns=metabolite.columns)
-    groups=list(OrderedDict.fromkeys(annot["group"])); nvar=[sum(annot["group"]==g) for g in groups]
+    annot = pd.DataFrame(
+        [{"metabolite": m, "group": g} for g, ms in mapping.items() for m in ms if m in metabolite.columns]
+    )
+    annot_unique = annot.drop_duplicates(subset="metabolite", keep="first")
+    metabolite = metabolite[annot_unique["metabolite"].tolist()]
+    eps = 1e-6
+    X_log = np.log(metabolite.values + eps)
+    X_scaled = StandardScaler().fit_transform(X_log)
+    metabolite_scaled = pd.DataFrame(X_scaled, columns=metabolite.columns)
+    groups = list(OrderedDict.fromkeys(annot_unique["group"]))
+    nvar = [sum(annot_unique["group"] == g) for g in groups]
     li=pd.read_csv("layerinfo.csv"); width=li["node_num"].tolist(); layer=li["layer_num"].tolist()
     cov_num=0;  
     if os.path.exists("cov.csv"): cov_num=len(pd.read_csv("cov.csv"))

--- a/compute_pvalues.py
+++ b/compute_pvalues.py
@@ -1,10 +1,25 @@
 import os
 import argparse
+from collections import OrderedDict
 import numpy as np
 import pandas as pd
 
+from DeepHisCoM_simulation import load_mapping
 
-def compute_pvalues(base_dir: str, n_perm: int = 100) -> None:
+
+def load_groups(mapping_file: str) -> list:
+    """Load pathway groups matching the training script."""
+    df_meta = pd.read_csv("181_metabolite_clinical.csv", index_col=0)
+    metabolite = df_meta.iloc[:, 14:]
+    mapping = load_mapping(mapping_file)
+    annot = pd.DataFrame(
+        [{"metabolite": m, "group": g} for g, ms in mapping.items() for m in ms if m in metabolite.columns]
+    )
+    annot_unique = annot.drop_duplicates(subset="metabolite", keep="first")
+    return list(OrderedDict.fromkeys(annot_unique["group"]))
+
+
+def compute_pvalues(base_dir: str, groups: list, n_perm: int = 100) -> None:
     """Compute permutation p-values for a single experiment directory."""
     obs_path = os.path.join(base_dir, "0", "param.txt")
     if not os.path.exists(obs_path):
@@ -29,7 +44,8 @@ def compute_pvalues(base_dir: str, n_perm: int = 100) -> None:
         pval = (greater + 1) / (len(perm_params) + 1)
         pvals.append(pval)
 
-    df = pd.DataFrame({"param_idx": range(len(obs_param)), "pvalue": pvals})
+    names = groups + [f"covariate_{i+1}" for i in range(len(obs_param) - len(groups))]
+    df = pd.DataFrame({"param": names[: len(obs_param)], "pvalue": pvals})
     df.to_csv(os.path.join(base_dir, "pvalue.csv"), index=False)
 
 
@@ -38,6 +54,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--start_sim", type=int, default=1, help="start simulation number")
     parser.add_argument("--end_sim", type=int, help="end simulation number (inclusive)")
     parser.add_argument("--exp_root", type=str, default="exp", help="root directory containing experiments")
+    parser.add_argument("--mapping_file", type=str, default="metabolite_mapping.set", help="pathway mapping file")
     parser.add_argument("--n_perm", type=int, default=100, help="number of permutations")
     return parser.parse_args()
 
@@ -51,6 +68,8 @@ def main() -> None:
     start_sim = args.start_sim
     end_sim = args.end_sim if args.end_sim is not None else start_sim
 
+    groups = load_groups(args.mapping_file)
+
     for sim_num in range(start_sim, end_sim + 1):
         sim_dir = os.path.join(exp_root, str(sim_num))
         if not os.path.isdir(sim_dir):
@@ -58,7 +77,7 @@ def main() -> None:
         for experiment in sorted(os.listdir(sim_dir)):
             base_dir = os.path.join(sim_dir, experiment)
             if os.path.isdir(base_dir):
-                compute_pvalues(base_dir, n_perm=args.n_perm)
+                compute_pvalues(base_dir, groups, n_perm=args.n_perm)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expose mapping file in compute_pvalues
- reuse mapping loader and filter metabolites like the training script
- label output p-values with group names and covariate indices

## Testing
- `python -m py_compile DeepHisCoM_simulation.py compute_pvalues.py generate_simulations.py`


------
https://chatgpt.com/codex/tasks/task_e_684aaae30bb083229372937f94783bef