### PR TITLE
Fix pathway beta output length

### DIFF
--- a/compute_pvalues.py
+++ b/compute_pvalues.py
@@ -6,7 +6,32 @@ import pandas as pd
 
 from DeepHisCoM_simulation import load_mapping
 
-def compute_pvalues(base_dir: str, n_perm: int = 100) -> None:
+
+def load_groups(mapping_file: str) -> list:
+    """Return pathway list matching the training script order."""
+    df_meta = pd.read_csv("181_metabolite_clinical.csv", index_col=0)
+    metabolite = df_meta.iloc[:, 14:]
+    mapping = load_mapping(mapping_file)
+
+    annot_rows = []
+    for g, ms in mapping.items():
+        for m in ms:
+            if m in metabolite.columns:
+                annot_rows.append({"metabolite": m, "group": g})
+
+    annot = pd.DataFrame(annot_rows)
+    groups = list(OrderedDict.fromkeys(annot["group"]))
+
+    valid_groups = []
+    for g in groups:
+        cols = annot.loc[annot.group == g, "metabolite"].tolist()
+        if len(cols) == 0:
+            continue
+        valid_groups.append(g)
+
+    return valid_groups
+
+def compute_pvalues(base_dir: str, groups: list, n_perm: int = 100) -> None:
     """Compute permutation p-values for a single experiment directory."""
     obs_path = os.path.join(base_dir, "0", "param.txt")
     if not os.path.exists(obs_path):
@@ -31,7 +56,9 @@ def compute_pvalues(base_dir: str, n_perm: int = 100) -> None:
         pval = (greater + 1) / (len(perm_params) + 1)
         pvals.append(pval)
 
-    df = pd.DataFrame({"param_idx": range(len(obs_param)), "pvalue": pvals})
+    cov_count = max(0, len(obs_param) - len(groups))
+    names = groups + [f"covariate_{i+1}" for i in range(cov_count)]
+    df = pd.DataFrame({"pathway": names[: len(obs_param)], "pvalue": pvals})
     df.to_csv(os.path.join(base_dir, "pvalue.csv"), index=False)
 
 
@@ -40,6 +67,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--start_sim", type=int, default=1, help="start simulation number")
     parser.add_argument("--end_sim", type=int, help="end simulation number (inclusive)")
     parser.add_argument("--exp_root", type=str, default="exp", help="root directory containing experiments")
+    parser.add_argument("--mapping_file", type=str, default="metabolite_mapping_intersection.set", help="pathway mapping file")
     parser.add_argument("--n_perm", type=int, default=100, help="number of permutations")
     return parser.parse_args()
 
@@ -53,6 +81,8 @@ def main() -> None:
     start_sim = args.start_sim
     end_sim = args.end_sim if args.end_sim is not None else start_sim
 
+    groups = load_groups(args.mapping_file)
+
     for sim_num in range(start_sim, end_sim + 1):
         sim_dir = os.path.join(exp_root, str(sim_num))
         if not os.path.isdir(sim_dir):
@@ -60,7 +90,7 @@ def main() -> None:
         for experiment in sorted(os.listdir(sim_dir)):
             base_dir = os.path.join(sim_dir, experiment)
             if os.path.isdir(base_dir):
-                compute_pvalues(base_dir, n_perm=args.n_perm)
+                compute_pvalues(base_dir, groups, n_perm=args.n_perm)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure mapping order is deterministic and keep duplicate metabolites
- write p-values with pathway names via new `load_groups`

## Testing
- `python3 -m py_compile compute_pvalues.py DeepHisCoM_simulation.py`


------
https://chatgpt.com/codex/tasks/task_e_684bfe6f2bf083229383117d3f9136e4