### PR TITLE
Store validation AUC for original data

### DIFF
--- a/DeepHisCoM_simulation.py
+++ b/DeepHisCoM_simulation.py
@@ -272,5 +272,7 @@ def main():
             np.savetxt(os.path.join(outd, "param.txt"), param)
             if perm == 0:
                 print(f"Original AUC: {auc:.4f}")
+                with open(os.path.join(outd, "val_auc.txt"), "w") as f:
+                    f.write(f"{auc}\n")
 
 if __name__ == "__main__": main()

--- a/Readme.md
+++ b/Readme.md
@@ -123,7 +123,9 @@ Procedure
    - Shuffle phenotype
    - Train DeepHisCoM
    - Track AUC / loss
-   - Save best weights to exp/tmp/param{perm}.txt
+   - Save best weights to `exp/tmp/param{perm}.txt`
+   - For the original data (perm=0) also write validation AUC to
+     `exp/tmp/val_auc.txt`
 
 ---
 


### PR DESCRIPTION
## Summary
- save validation AUC for the unpermuted dataset when running simulations
- document the new `val_auc.txt` output file

## Testing
- `python -m py_compile DeepHisCoM_simulation.py compute_pvalues.py generate_simulations.py`
- `python DeepHisCoM_simulation.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c1814b95c832281d9ffc442e36179