### PR TITLE
Store validation AUC and predictions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -123,7 +123,10 @@ Procedure
    - Shuffle phenotype
    - Train DeepHisCoM
    - Track AUC / loss
-   - Save best weights to exp/tmp/param{perm}.txt
+   - Save best weights to `exp/tmp/param{perm}.txt`
+   - For the original data (perm=0) also write validation AUC to
+     `exp/tmp/val_auc.txt` and store per-sample predictions in
+     `exp/tmp/val_pred.txt`
 
 ---
 


### PR DESCRIPTION
## Summary
- save validation predictions and AUC when training with original data
- mention new `val_pred.txt` output in docs

## Testing
- `python -m py_compile DeepHisCoM_simulation.py compute_pvalues.py generate_simulations.py`
- `python DeepHisCoM_simulation.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_684c1814b95c832281d9ffc442e36179