### PR TITLE
Add weight init and L2 norm options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -101,11 +101,13 @@ Each CSV contains
 --learning_rate …  
 --activation tanh | relu | leakyrelu | identity  
 --loss BCELoss | MSELoss  
---reg_type l1 | l2  
---reg_const_pathway_disease  
---reg_const_bio_pathway  
---stop_type Early-stopping rule  
---divide_rate Train/test split ratio  
+--reg_type l1 | l2
+--reg_const_pathway_disease
+--reg_const_bio_pathway
+--weight_init xavier | constant
+--pathway_l2norm Flag to apply L2-normalization after BatchNorm
+--stop_type Early-stopping rule
+--divide_rate Train/test split ratio
 --count_lim Patience for stopping
 
 ### Running Permutations


### PR DESCRIPTION
## Summary
- expose choice of weight initialization (`xavier` or `constant`)
- option to apply L2-normalization after the pathway batch norm
- implement L1/L2 regularization terms in training loop
- document new CLI flags in README

## Testing
- `python -m py_compile DeepHisCoM_simulation.py`

------
https://chatgpt.com/codex/tasks/task_e_68523fba968483229ae2b31b0bef9347