### PR TITLE
Add BH FDR correction and bar chart trends

### DIFF
--- a/analyze_power_fdr.py
+++ b/analyze_power_fdr.py
@@ -5,6 +5,18 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
+def _bh_qvalues(pvals: np.ndarray) -> np.ndarray:
+    """Return Benjamini-Hochberg FDR-adjusted q-values."""
+    pvals = np.asarray(pvals, dtype=float)
+    n = len(pvals)
+    order = np.argsort(pvals)
+    ranks = np.empty(n, int)
+    ranks[order] = np.arange(1, n + 1)
+    qvals = pvals * n / ranks
+    qvals[order[::-1]] = np.minimum.accumulate(qvals[order[::-1]])
+    return np.minimum(qvals, 1.0)
+
+
 def _parse_condition(name: str) -> tuple[str, str, float]:
     """Return scenario, parameter label, and numeric value from a condition name."""
     m = re.search(r"^(linear|interaction|quadratic)_(beta|w)_([0-9.]+)", name)
@@ -26,7 +38,8 @@ def compute_metrics(result_dir: str, true_groups=None, alpha: float = 0.05):
         Pathway names with a true association. Defaults to
         ["map00400", "map00860"].
     alpha : float, default 0.05
-        Significance threshold for declaring discoveries.
+        Significance threshold for declaring discoveries after
+        Benjamini-Hochberg FDR correction.
 
     Saves per-experiment ``empirical_power_<cond>.png`` and ``fdr_<cond>.png``
     in ``result_dir`` and prints a summary table.
@@ -56,7 +69,8 @@ def compute_metrics(result_dir: str, true_groups=None, alpha: float = 0.05):
 
     for exp, tables in sorted(pval_by_exp.items()):
         df_all = pd.concat(tables, ignore_index=True)
-        df_all["reject"] = df_all["pvalue"] <= alpha
+        df_all["qvalue"] = _bh_qvalues(df_all["pvalue"].values)
+        df_all["reject"] = df_all["qvalue"] <= alpha
 
         power_df = (
             df_all[df_all["pathway"].isin(true_groups)]
@@ -64,14 +78,19 @@ def compute_metrics(result_dir: str, true_groups=None, alpha: float = 0.05):
             .mean()
             .reset_index(name="empirical_power")
         )
+        combined_power = power_df["empirical_power"].mean()
+        power_df = pd.concat(
+            [power_df, pd.DataFrame({"pathway": ["combined"], "empirical_power": [combined_power]})],
+            ignore_index=True,
+        )
 
         total_rejects = int(df_all["reject"].sum())
         false_rejects = df_all[~df_all["pathway"].isin(true_groups) & df_all["reject"]]
-        fdr = len(false_rejects) / total_rejects if total_rejects else 0.0
+        fdr_value = len(false_rejects) / total_rejects if total_rejects else 0.0
 
         scen, label, val = _parse_condition(exp)
         info = scenario_data.setdefault(scen, {"label": label, "vals": []})
-        info["vals"].append((val, power_df, fdr))
+        info["vals"].append((val, power_df, fdr_value))
 
         # Plot empirical power for this experiment
         ax = power_df.plot(kind="bar", x="pathway", y="empirical_power", legend=False)
@@ -80,16 +99,16 @@ def compute_metrics(result_dir: str, true_groups=None, alpha: float = 0.05):
         ax.set_ylim(0, 1)
         ax.set_title(f"{exp} (alpha={alpha})")
         plt.tight_layout()
-        plt.savefig(os.path.join(result_dir, f"empirical_power_{exp}.png"))
+        plt.savefig(os.path.join(result_dir, f"empirical_power_{exp}_a{alpha}.png"))
         plt.close()
 
         # Plot FDR for this experiment
-        plt.bar(["FDR"], [fdr])
+        plt.bar(["FDR"], [fdr_value])
         plt.ylim(0, 1)
         plt.ylabel("FDR")
         plt.title(f"{exp} (alpha={alpha})")
         plt.tight_layout()
-        plt.savefig(os.path.join(result_dir, f"fdr_{exp}.png"))
+        plt.savefig(os.path.join(result_dir, f"fdr_{exp}_a{alpha}.png"))
         plt.close()
 
         for _, row in power_df.iterrows():
@@ -97,47 +116,59 @@ def compute_metrics(result_dir: str, true_groups=None, alpha: float = 0.05):
                 "experiment": exp,
                 "pathway": row["pathway"],
                 "empirical_power": row["empirical_power"],
-                "FDR": fdr,
+                "FDR": fdr_value,
             })
 
         print(power_df)
-        print(f"{exp} FDR: {fdr:.4f}")
+        print(f"{exp} FDR: {fdr_value:.4f}")
 
     # Generate trend plots grouped by scenario
     for scen, info in scenario_data.items():
         vals = sorted(info["vals"], key=lambda x: x[0])
         params = [v[0] for v in vals]
+        labels = [f"{info['label']} = {v}" for v in params]
         power_traces = {g: [] for g in true_groups}
+        power_traces["combined"] = []
         fdr_list = []
         for val, p_df, fdr in vals:
             for g in true_groups:
                 row = p_df.loc[p_df.pathway == g, "empirical_power"]
                 power_traces[g].append(row.iloc[0] if not row.empty else 0)
-            fdr_list.append(fdr)
+            comb_row = p_df.loc[p_df.pathway == "combined", "empirical_power"]
+            power_traces["combined"].append(comb_row.iloc[0] if not comb_row.empty else 0)
+        fdr_list.append(fdr)
 
+        x = np.arange(len(params))
+        width = 0.8 / len(power_traces)
         fig, ax = plt.subplots()
-        for g, pvals in power_traces.items():
-            ax.plot(params, pvals, marker="o", label=g)
-        ax.set_xlabel(info["label"])
+        for i, (g, pvals) in enumerate(power_traces.items()):
+            offset = (i - (len(power_traces) - 1) / 2) * width
+            ax.bar(x + offset, pvals, width, label=g)
+        ax.set_xticks(x)
+        ax.set_xticklabels(labels, rotation=45, ha="right")
         ax.set_ylabel("Empirical Power")
         ax.set_title(f"{scen} (alpha={alpha})")
         ax.set_ylim(0, 1)
         ax.legend()
         plt.tight_layout()
-        plt.savefig(os.path.join(result_dir, f"trend_power_{scen}.png"))
+        plt.savefig(os.path.join(result_dir, f"trend_power_{scen}_a{alpha}.png"))
         plt.close()
 
-        plt.plot(params, fdr_list, marker="o")
-        plt.xlabel(info["label"])
-        plt.ylabel("FDR")
-        plt.title(f"{scen} (alpha={alpha})")
-        plt.ylim(0, 1)
+        fig, ax = plt.subplots()
+        ax.bar(x, fdr_list, width=0.6)
+        ax.set_xticks(x)
+        ax.set_xticklabels(labels, rotation=45, ha="right")
+        ax.set_ylabel("FDR")
+        ax.set_title(f"{scen} (alpha={alpha})")
+        ax.set_ylim(0, 1)
         plt.tight_layout()
-        plt.savefig(os.path.join(result_dir, f"trend_fdr_{scen}.png"))
+        plt.savefig(os.path.join(result_dir, f"trend_fdr_{scen}_a{alpha}.png"))
         plt.close()
 
     summary_df = pd.DataFrame(summary_rows)
-    summary_df.to_csv(os.path.join(result_dir, "power_fdr_summary.csv"), index=False)
+    summary_df.to_csv(
+        os.path.join(result_dir, f"power_fdr_summary_a{alpha}.csv"), index=False
+    )
 
 
 def main():
@@ -148,7 +179,8 @@ def main():
     if not os.path.isdir(result_dir):
         print(f"Directory '{result_dir}' does not exist.")
         return
-    compute_metrics(result_dir)
+    for a in (0.05, 0.1):
+        compute_metrics(result_dir, alpha=a)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- adjust `analyze_power_fdr.py` to evaluate q-values using Benjamini-Hochberg
- compute metrics for alpha 0.05 and 0.1
- plot trends with bar charts using parameter labels in x-axis
- output files include alpha in the filename
- compute and visualize combined power for both pathways

## Testing
- `python -m py_compile analyze_power_fdr.py compute_pvalues.py DeepHisCoM_simulation.py generate_simulations.py`


------
https://chatgpt.com/codex/tasks/task_e_68524bcaf4a88322b54f079858533cb0